### PR TITLE
CDC-46 Add support for Antlr 4.10.1

### DIFF
--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -3,13 +3,18 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load(":lang.bzl", "C", "CPP", "GO", "JAVA", "OBJC", "PYTHON", "PYTHON2", "PYTHON3", supportedLanguages = "supported")
 
-v4 = [4, "4.7.1", "4.7.2", "4.8"]
+v4 = [4, "4.7.1", "4.7.2", "4.8", "4.10.1"]
 v4_opt = [4, "4.7.1", "4.7.2", "4.7.3", "4.7.4"]
 v3 = [3, "3.5.2"]
 v2 = [2, "2.7.7"]
 
 PACKAGES = {
     "antlr": {
+        "4.10.1": {
+            "url": "https://github.com/antlr/antlr4/archive/4.10.1.tar.gz",
+            "prefix": "antlr4-4.10.1",
+            "sha256": "a320568b738e42735946bebc5d9d333170e14a251c5734e8b852ad1502efa8a2",
+        },
         "4.8": {
             "url": "https://github.com/antlr/antlr4/archive/4.8.tar.gz",
             "prefix": "antlr4-4.8",
@@ -38,6 +43,10 @@ PACKAGES = {
         },
     },
     "antlr4_runtime": {
+        "4.10.1": {
+            "path": "org/antlr/antlr4-runtime/4.10.1/antlr4-runtime-4.10.1.jar",
+            "sha256": "da66be0c98acfb29bc708300d05f1a3269c40f9984a4cb9251cf2ba1898d1334",
+        },
         "4.8": {
             "path": "org/antlr/antlr4-runtime/4.8/antlr4-runtime-4.8.jar",
             "sha256": "2337df5d81e715b39aeea07aac46ad47e4f1f9e9cd7c899f124f425913efdcf8",
@@ -68,6 +77,10 @@ PACKAGES = {
         },
     },
     "antlr4_tool": {
+        "4.10.1": {
+            "path": "org/antlr/antlr4/4.10.1/antlr4-4.10.1.jar",
+            "sha256": "6bef3dad65a1bd55533981d7ef694d27dcfb4e7a70f560dd026c8895b35a7468",
+        },
         "4.8": {
             "path": "org/antlr/antlr4/4.8/antlr4-4.8.jar",
             "sha256": "6e4477689371f237d4d8aa40642badbb209d4628ccdd81234d90f829a743bac8",
@@ -179,7 +192,9 @@ def rules_antlr_dependencies(*versionsAndLanguages):
             languages = [JAVA]
 
         for version in sorted(versions, key = _toString):
-            if version == 4 or version == "4.8":
+            if version == 4 or version == "4.10.1":
+                _antlr4101_dependencies(languages)
+            elif version == "4.8":
                 _antlr48_dependencies(languages)
             elif version == "4.7.2":
                 _antlr472_dependencies(languages)
@@ -216,6 +231,19 @@ def rules_antlr_optimized_dependencies(version):
         fail('Integer version \'{}\' no longer valid. Use semantic version "{}" instead.'.format(version, ".".join(str(version).elems())), attr = "version")
     else:
         fail('Unsupported ANTLR version provided: "{0}". Currently supported are: {1}'.format(version, v4_opt), attr = "version")
+
+def _antlr4101_dependencies(languages):
+    _antlr4_dependencies(
+        "4.10.1",
+        languages,
+        {
+            "antlr4_runtime": "4.10.1",
+            "antlr4_tool": "4.10.1",
+            "antlr3_runtime": "3.5.2",
+            "stringtemplate4": "4.3",
+            "javax_json": "1.0.4",
+        },
+    )
 
 def _antlr48_dependencies(languages):
     _antlr4_dependencies(


### PR DESCRIPTION
The `rules_antlr` repository is not actively maintained and the rule only has support till version `4.8`. This PR adds support for version `4.10.1`, copying other forks that do the same for version `4.13`.